### PR TITLE
fixed test for icon to add and remove search conditions

### DIFF
--- a/features/elements.feature
+++ b/features/elements.feature
@@ -1,33 +1,31 @@
 Feature: Elements
-	As a registered user, 
-	I want to see labels for the form fields of the search constraints, so that I can be sure what to enter
+  As a registered user,
+  I want to see labels for the form fields of the search constraints, so that I can be sure what to enter
 
 Background:
-	Given I'm logged in as user
-	And I am on the search page
+  Given I'm logged in as user
+  And I am on the search page
 
 Scenario: Methodologies Label
-	Then I should see "Methodologies" 
+  Then I should see "Methodologies"
 
 Scenario: Methods Label
-	Then I should see "Methods" 
+  Then I should see "Methods"
 
 Scenario: Search by  Label
-	Then I should see "Search by" 
+  Then I should see "Search by"
 
 Scenario: Criteria Label
-	Then I should see "Criteria" 
+  Then I should see "Criteria"
 
 Scenario: Additional info Label
-	Then I should see "Additional info" 
+  Then I should see "Additional info"
 
 Scenario: Additional info Label
-	Then I should see "Additional info" 
+  Then I should see "Additional info"
 
 Scenario: plus sign for add
-	Then I should see "glyphicon glyphicon-plus" in css
+  Then I should see "i.glyphicon.glyphicon-plus" in css
 
-Scenario: minus sign for remove 
-	Then I should see "glyphicon glyphicon-minus" in css
-
-
+Scenario: minus sign for remove
+  Then I should see "i.glyphicon.glyphicon-plus" in css

--- a/features/step_definitions/content_check_steps.rb
+++ b/features/step_definitions/content_check_steps.rb
@@ -19,7 +19,7 @@ Then(/^I should not see "(.*?)"$/) do |arg1|
 end
 
 Then(/^I should see "(.*?)" in css$/) do |arg|
-  should have_css(arg)
+  expect(page).to have_css(arg)
 end
 
 Then(/^I should see results in a table$/) do


### PR DESCRIPTION
in reply to https://github.com/sdm15stream2/serler/commit/af78a09254c492cf54d15b0bee53f7ae55355ca8#commitcomment-13829661

In the `.feature` file: `i.` is the HTML element used, you can remove this prefix if you feel this assumption is too strong and might be inflexible in the future.